### PR TITLE
implement zustand useFileExplorer hook, set template data when playgr…

### DIFF
--- a/app/playground/[id]/page.tsx
+++ b/app/playground/[id]/page.tsx
@@ -3,26 +3,44 @@ import { Separator } from "@/components/ui/separator";
 import { SidebarInset, SidebarTrigger } from "@/components/ui/sidebar";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { TemplateFileTree } from "@/modules/playground/components/playground-explorer";
+import { useFileExplorer } from "@/modules/playground/hooks/useFileExplorer";
 import { usePlayground } from "@/modules/playground/hooks/usePlayground";
+import { TemplateFile } from "@/modules/playground/lib/path-to-json";
 import { useParams } from "next/navigation";
-import React from "react";
+import React, { useEffect } from "react";
 
 const MainPlaygroundPage = () => {
   const { id } = useParams<{ id: string }>();
 
   const { playgroundData, templateData, isLoading, error, saveTemplateData} = usePlayground(id);
+  const { activeFileId, closeAllFiles, openFile, openFiles, setTemplateData, setActiveFileId, setPlaygroundId, setOpenFiles } = useFileExplorer();
 
-  console.log("TemplateData: ", templateData);
-  console.log("PlaygroundData: ", playgroundData);
+  // console.log("TemplateData: ", templateData);
+  // console.log("PlaygroundData: ", playgroundData);
 
-  const activeFile = "sample.txt";
+  useEffect(()=> {
+    setPlaygroundId(id);
+  }, [id, setPlaygroundId]);
+
+  useEffect(()=>{
+    if(templateData && !openFiles.length){
+      setTemplateData(templateData);
+    }
+  }, [templateData, setTemplateData, openFiles.length]);
+
+  const activeFile = openFiles.find((file)=> file.id === activeFileId);
+  const hasUnsavedChanges = openFiles.some((file)=> file.hasUnsavedChanges);
+
+  const handleFileSelect = (file:TemplateFile)=>{
+    openFile(file);
+  }
 
   return (
     <TooltipProvider>
       <>
       <TemplateFileTree
       data={templateData!}
-      onFileSelect = {()=> {}}
+      onFileSelect = {handleFileSelect}
       selectedFile={activeFile}
       title="File Explorer"
       onAddFile={()=>{}}

--- a/modules/playground/hooks/useFileExplorer.tsx
+++ b/modules/playground/hooks/useFileExplorer.tsx
@@ -1,0 +1,110 @@
+import {create} from "zustand";
+import {toast} from "sonner";
+
+import { TemplateFile, TemplateFolder } from "../lib/path-to-json";
+import { generateFileId } from "../lib";
+
+interface OpenFile extends TemplateFile{
+    id:string;
+    hasUnsavedChanges:boolean;
+    content: string;
+    originalContent: string;
+}
+
+interface FileExplorerState {
+    playgroundId: string;
+    templateData: TemplateFolder | null;
+    openFiles: OpenFile[];
+    activeFileId: string | null;
+    editorContent: string;
+
+    // Setter Functions
+    setPlaygroundId: (id:string) => void;
+    setTemplateData: (data: TemplateFolder | null)=> void;
+    setEditorContent: (content: string) => void;
+    setOpenFiles: (files: OpenFile[]) => void;
+    setActiveFileId: (fileId: string | null) => void;
+
+    // Functions
+    openFile: (file: TemplateFile) => void;
+    closeFile: (fileId: string) => void;
+    closeAllFiles: ()=> void;
+}
+
+export const useFileExplorer = create<FileExplorerState>((set, get)=> ({
+    templateData: null,
+    playgroundId: "",
+    openFiles: [] satisfies OpenFile[],
+    activeFileId: null,
+    editorContent: "",
+
+    setTemplateData: (data) => set({templateData: data}),
+    setPlaygroundId(id){
+        set({playgroundId: id});
+    },
+    setEditorContent: (content) => set({editorContent: content}),
+    setOpenFiles: (files) => set({openFiles: files}),
+    setActiveFileId: (fileId) => set({activeFileId: fileId}),
+
+    openFile: (file) => {
+        const fileId = generateFileId(file, get().templateData!);
+        const {openFiles} = get();
+        const existingFile = openFiles.find((f)=> f.id === fileId);
+
+        if(existingFile){
+            set({activeFileId: fileId, editorContent: existingFile.content});
+            return;
+        }
+
+        const newOpenFile: OpenFile = {
+            ...file,
+            id: fileId,
+            hasUnsavedChanges: false,
+            content: file.content || "",
+            originalContent: file.content || "",
+        };
+
+        set((state) => ({
+            openFiles: [...state.openFiles, newOpenFile],
+            activeFileId: fileId,
+            editorContent: file.content || "",
+        }));
+    },
+
+    closeFile: (fileId) => {
+        const {openFiles, activeFileId} = get();
+        const newFiles = openFiles.filter((f)=> f.id !== fileId);
+
+        // If we're closing the active file, switch to another file or clear active
+        let newActiveFileId = activeFileId;
+        let newEditorContent = get().editorContent;
+
+        if(activeFileId === fileId){
+            if(newFiles.length > 0){
+                const lastFile = newFiles[newFiles.length - 1];
+                newActiveFileId = lastFile.id;
+                newEditorContent = lastFile.content;
+            }else{
+                newActiveFileId = null;
+                newEditorContent = "";
+            }
+        }
+
+        set({
+            openFiles: newFiles,
+            activeFileId: newActiveFileId,
+            editorContent: newEditorContent
+        });
+
+    },
+
+    closeAllFiles: ()=> {
+        set({
+            openFiles: [],
+            activeFileId: null,
+            editorContent: "",
+        });
+    },
+
+}));
+

--- a/modules/playground/lib/index.ts
+++ b/modules/playground/lib/index.ts
@@ -1,0 +1,45 @@
+import { TemplateFile, TemplateFolder } from "./path-to-json";
+
+export function findFilePath(
+    file: TemplateFile,
+    folder: TemplateFolder,
+    pathSoFar: string[] = []
+): string | null {
+    for (const item of folder.items) {
+        if ("folderName" in item) {
+            const res = findFilePath(file, item, [...pathSoFar, item.folderName]);
+            if (res) return res;
+        } else {
+            if (
+                item.filename === file.filename &&
+                item.fileExtension === file.fileExtension
+            ) {
+                return [
+                    ...pathSoFar,
+                    item.filename + (item.fileExtension ? "." + item.fileExtension : ""),
+                ].join("/");
+            }
+        }
+    }
+    return null;
+}
+
+/**
+ * Generates a unique file ID based on file location in folder structure
+ * @param file The template file
+ * @param rootFolder The root template folder containing all files
+ * @returns A unique file identifier including full path
+ */
+export const generateFileId = (file: TemplateFile, rootFolder: TemplateFolder): string => {
+    // Find the file's path in the folder structure
+    const path = findFilePath(file, rootFolder)?.replace(/^\/+/, '') || '';
+
+    // Handle empty/undefined file extension
+    const extension = file.fileExtension?.trim();
+    const extensionSuffix = extension ? `.${extension}` : '';
+
+    // Combine path and filename
+    return path
+        ? `${path}/${file.filename}${extensionSuffix}`
+        : `${file.filename}${extensionSuffix}`;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,8 @@
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.3.1",
         "vaul": "^1.1.2",
-        "zod": "^4.1.11"
+        "zod": "^4.1.11",
+        "zustand": "^5.0.8"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -8687,6 +8688,35 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.8.tgz",
+      "integrity": "sha512-gyPKpIaxY9XcO2vSMrLbiER7QMAMGOQZVRdJ6Zi782jkbzZygq5GI9nG8g+sMgitRtndwaBSl7uiqC49o1SSiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.3.1",
     "vaul": "^1.1.2",
-    "zod": "^4.1.11"
+    "zod": "^4.1.11",
+    "zustand": "^5.0.8"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",


### PR DESCRIPTION
implement zustand useFileExplorer hook, set template data when playground loads, add activeFile and hasUnsavedChangs variables, implement handleFileSelect

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a file explorer in Playground: select and open files, track the active file, and manage multiple open files.
  * Automatically syncs editor content with the selected file and indicates unsaved changes.
  * Supports closing individual files or closing all files at once.
  * Initializes file list from template data and keeps the Playground in sync with the current page.

* **Chores**
  * Added a state management dependency to support the new file explorer experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->